### PR TITLE
[data-spec] Start/stop mode Interface

### DIFF
--- a/vehicle_data/data_spec.html
+++ b/vehicle_data/data_spec.html
@@ -839,6 +839,19 @@
 
 </section>
 
+<!------------------------ Interface StartStopMode ------------------------------>
+<section>
+  <h3><a>StartStopMode</a> Interface</h3>
+  <p>The <a>StartStopMode</a> interface provides information about the status of start/stop feature of the vehicle, whereby the engine shuts off instead of idling while stationary.</p>
+  <dl title="interface StartStopMode : VehicleCommonDataType" class="idl">
+    <dt>readonly attribute boolean? startStopEnabled</dt>
+    <dd>MUST return true if start/stop is enabled</dd>
+    <dt>readonly attribute boolean? startStopActive</dt>
+    <dd>MUST return true if start/stop is currently active</dd>
+  </dl>
+
+</section>
+
 </section>
 <!------------------- End of Running Status Interfaces ---------------------->
 <!--------------------------------------------------------------------------->


### PR DESCRIPTION
<b>Start/stop mode </b>- the engine shuts off instead of idling while stationary.
- Boolean to show if start / stop mode is enabled 
- Boolean for when start / stop mode is currently active. 

As discussed in <a href="https://github.com/w3c/automotive/issues/18">Issue 18: [data-spec] Power Modes - Cranking</a>, since there is no powermode to represent this state.
Further discussion required for potential hybrid <i>powermodes</i>.