### PR TITLE
[data-spec] SteeringWheelConfiguration Update: Steering Wheel Location

### DIFF
--- a/vehicle_data/data_spec.html
+++ b/vehicle_data/data_spec.html
@@ -305,8 +305,8 @@
   information about a vehicle.</p>
 
   <dl title="interface SteeringWheelConfiguration : VehicleCommonDataType" class="idl">
-     <dt>readonly attribute boolean? steeringWheelLeft</dt>
-     <dd>MUST return true if steering wheel is on left side of vehicle</dd>
+     <dt>readonly attribute Zone? steeringWheelLocation</dt>
+     <dd>MUST return the location on the steering wheel within the vehicle</dd> 
      <dt>attribute unsigned short? steeringWheelTelescopingPosition</dt>
      <dd>MUST return steering wheel position as percentage of extension from the dash
      (Unit: percentage, 0%:closest to dash, 100%:farthest from dash)


### PR DESCRIPTION
As discussed in <a href="https://github.com/w3c/automotive/issues/17">Issue 17</a>.
In order to remove ambiguity and allow for any orientation of steering wheel (and null in the case of no steering wheel) this interface has been updated from:

<pre>
steeringWheelLeft of type boolean, readonly , nullable
must return true if steering wheel is on left side of vehicle
</pre>
to
<pre>
steeringWheelLocation of type Zone, readonly , nullable
must return the location on the steering wheel within the vehicle
</pre>