### PR TITLE
Add participation data to spec's boilerplate

### DIFF
--- a/vehicle_data/data_spec.html
+++ b/vehicle_data/data_spec.html
@@ -35,6 +35,26 @@
             companyURL: "http://www.intel.com/"              
           }],
           edDraftURI:           "http://rawgit.com/w3c/automotive/master/vehicle_data/data_spec.html",
+
+          otherLinks: [{
+            key: 'Repository and Participation',
+            data: [
+                {
+                    value: 'We are on github.',
+                    href: 'https://github.com/w3c/automotive/'
+                }, {
+                    value: 'File a bug/issue.',
+                    href: 'https://github.com/w3c/automotive/issues'
+                }, {
+                    value: 'Commit history.',
+                    href: 'https://github.com/w3c/automotive/commits'
+                }, {
+                    value: 'Mailing list archive.',
+                    href: 'https://lists.w3.org/Archives/Public/public-automotive/'
+                }
+             ]
+          }],
+
           wg:           "Automotive Working Group",
           wgURI:        "http://www.w3.org/auto/wg/",
           wgPublicList: "public-automotive",

--- a/vehicle_data/vehicle_spec.html
+++ b/vehicle_data/vehicle_spec.html
@@ -36,6 +36,26 @@
           }],
           edDraftURI:           "http://rawgit.com/w3c/automotive/master/vehicle_data/vehicle_spec.html",
           wg:           "Automotive Working Group",
+
+          otherLinks: [{
+            key: 'Repository and Participation',
+            data: [
+                {
+                    value: 'We are on github.',
+                    href: 'https://github.com/w3c/automotive/'
+                }, {
+                    value: 'File a bug/issue.',
+                    href: 'https://github.com/w3c/automotive/issues'
+                }, {
+                    value: 'Commit history.',
+                    href: 'https://github.com/w3c/automotive/commits'
+                }, {
+                    value: 'Mailing list archive.',
+                    href: 'https://lists.w3.org/Archives/Public/public-automotive/'
+                }
+             ]
+          }],
+
           wgURI:        "http://www.w3.org/auto/wg/",
           wgPublicList: "public-automotive",
           wgPatentURI: "http://www.w3.org/2004/01/pp-impl/76043/status",


### PR DESCRIPTION
It's now common practice to include "repository and participation" data in the spec's boilerplate and the PR adds that data.