### PR TITLE
Remove requestId from a example of subscribe section

### DIFF
--- a/vehicle_data/vehicle_information_service.html
+++ b/vehicle_data/vehicle_information_service.html
@@ -1117,7 +1117,6 @@
 
   <pre class="highlight hljs javascript">
   receive <- {
-		"requestId": 1004,
     "subscriptionId": 35472,
     "path": "Signal.Drivetrain.Transmission.TripMeter",
     "timestamp": &lt;DOMTimeStamp&gt;,


### PR DESCRIPTION
- To make a sync with changed subscriptionNotification interface, removed requestId from notification JSON message of subscribe example.
