### PR TITLE
simplifying abstract for fixing issue #104(trim abstract)

### DIFF
--- a/vehicle_data/vehicle_information_service.html
+++ b/vehicle_data/vehicle_information_service.html
@@ -105,7 +105,7 @@
   <body>
     <!-- Abstract -->
     <section id="abstract">
-	<p>TThis specification defines a websocket based API for vehicle signal server that provide the functionality for client applications to access vehicle signals and data attributes.
+	<p>This specification defines a websocket based API for vehicle signal server that provide the functionality for client applications to access vehicle signals and data attributes.
     </section>
 
     <!-- Status of this document -->

--- a/vehicle_data/vehicle_information_service.html
+++ b/vehicle_data/vehicle_information_service.html
@@ -105,8 +105,9 @@
   <body>
     <!-- Abstract -->
     <section id="abstract">
-	<p>This specification defines a websocket based API for vehicle signal server that provide the functionality for client applications to access vehicle signals and data attributes.
-    </section>
+	<p>This specification defines a WebSocket based API for a vehicle signal server that provides the functionality for client applications to get, set, subscribe and unsubscribe to vehicle signals and data attributes.</p>
+	<p>The purpose of the specification is to promote a Server API that enables application development in a consistent manner across participating automotive manufacturers.</p>
+	  </section>
 
     <!-- Status of this document -->
     <section id="sotd">

--- a/vehicle_data/vehicle_information_service.html
+++ b/vehicle_data/vehicle_information_service.html
@@ -105,32 +105,7 @@
   <body>
     <!-- Abstract -->
     <section id="abstract">
-	<p>The W3C Vehicle Signal Server Specification defines a WebSocket based API that enables
-	client applications to GET, SET, SUBSCRIBE and UNSUBSCRIBE to vehicle signals and data attributes.</p>
-
-	<p>The purpose of the specification is to promote a Server API that enables application
-	development in a consistent manner across participating automotive manufacturers.</p>
-
-	<p>It is recommended that this Vehicle Signal Server Specification (VSSS) is read in conjunction with the
-	W3C Vehicle Signal Client Specification (VSCS) and the GENIVI Vehicle Signal Specification (VSS).</p>
-
-	<p>The Vehicle Signal Client Specification defines an API that wraps the data access and security primitives
-	defined in this Server Specification. It has been defined to support the development
-	of 'standards-compliant' JavaScript libraries that can be used by web based clients. The GENIVI Vehicle Signal
-	Specification (VSS) defines the set of vehicle signals and data that are exposed via this Server Specification. </p>
-
-	<p>This Server Specification describes a discovery mechanism that defines the set of signals and data
-	that a client can access at a particular point in time. It is recognized that some automobile
-	manufacturers may expose more signals and data than others. The Vehicle Signal Specification (VSS) supports both
-	extensibility and the ability to define private branches.</p>
-
-	<p>In addition, the 'tree' of signals that is accessible at any point in time may also vary depending
-	on standard access control principles. That is, it can vary based on the identity of the user (person or
-	organisation) requesting the data and/or the device (e.g. vehicle) where the request originates.</p>
-
-	<p>To support this, the Server Specification describes an extensible token based security mechanism that can
-	optionally be used to pass tokens to the WebSocket Server, for example to represent the user of an application
-	and/or the device that the client application is running on.</p>
+	<p>TThis specification defines a websocket based API for vehicle signal server that provide the functionality for client applications to access vehicle signals and data attributes.
     </section>
 
     <!-- Status of this document -->


### PR DESCRIPTION
Typically abstract part in the W3C spec is described shortly so that I made one simple sentence using existing abstract.  The rest description of previous abstract need to be merged with Introduction
part of the spec.