### PR TITLE
WebSocket security token diagram clarification

### DIFF
--- a/vehicle_data/vehicle_information_service.html
+++ b/vehicle_data/vehicle_information_service.html
@@ -408,7 +408,7 @@
 
         <figure>
           <img src="images/WebSocket_Security_Flow_1_600px.png" alt="WebSocket Security token flow">
-          <figcaption>Diagram showing conceptual WebSocket Security Token flow (data structures are for demonstrative purposes only)</figcaption>
+          <figcaption>Diagram showing conceptual WebSocket Security Token flow (data structures are illustrative only)</figcaption>
         </figure>
 
 	      <p class="note">TODO: Update diagram to reflect auth token structure and review including other diagrams from Wiki</p>

--- a/vehicle_data/vehicle_information_service.html
+++ b/vehicle_data/vehicle_information_service.html
@@ -408,7 +408,7 @@
 
         <figure>
           <img src="images/WebSocket_Security_Flow_1_600px.png" alt="WebSocket Security token flow">
-          <figcaption>Diagram showing WebSocket Security Token flow</figcaption>
+          <figcaption>Diagram showing conceptual WebSocket Security Token flow (data structures are for demonstrative purposes only)</figcaption>
         </figure>
 
 	      <p class="note">TODO: Update diagram to reflect auth token structure and review including other diagrams from Wiki</p>


### PR DESCRIPTION
The diagram in Figure 3 does not use the exact data structures from the specification, but it is demonstrative and simpler than including the actual structures which would need additional fields, such as timestamps and requestIds. For simplicity I think the diagram should remain the same, but it is important to note that it is conceptual.