### PR TITLE
Note on wwwivi as a hostname

### DIFF
--- a/vehicle_data/vehicle_information_service.html
+++ b/vehicle_data/vehicle_information_service.html
@@ -482,6 +482,10 @@
 	<pre class="highlight hljs javascript">
 	  <span class="hljs-keyword">var</span> vehicle  = new WebSocket("wss://wwwivi", "wvss1.0");
 	</pre>
+	
+	<p class="note">Discuss merits of using 'wwwivi' as a standardised hostname. Do we want a more generic 
+		hostname, not just for IVI but also encompassing WoT standards?</p>
+	      
 	<p>RESTful web services are out of scope for the first revision of
 	this specification, but could be considered for addition in a later
 	version.</p>


### PR DESCRIPTION
Discuss merits of using 'wwwivi' as a standardised hostname. Do we want a more generic hostname, not just for IVI but also encompassing WoT standards?