### PR TITLE
Some spelling fixes

### DIFF
--- a/vehicle_information_api/vehicle_information_api_specification.html
+++ b/vehicle_information_api/vehicle_information_api_specification.html
@@ -174,7 +174,7 @@
       </p>
       <p>
       Some part of vehicle data is considered as privacy sensitive and client programs SHOULD treat these data with respect to the user's right.
-      As a privacy protection enforcer, the VIAS implementation MUST obtain user's permision for exposing vehicle data to a client program.
+      As a privacy protection enforcer, the VIAS implementation MUST obtain user's permission for exposing vehicle data to a client program.
       If the implementation have an exceptional behavior to treat private information in emergent cases, the behavior also SHOULD be covered by the permission.
       </p>
     </section>
@@ -286,7 +286,7 @@
         <tr>
           <th>Method</th>
           <th>Description</th>
-          <th>Paramters</th>
+          <th>Parameters</th>
         </tr>
         <tr>
           <td><dfn>connect</dfn> (connectCallback, errorCallback)</td>
@@ -504,7 +504,7 @@
 
       <h3><dfn>VISError</dfn> Dictionary</h3>
       <p>
-      Error number, reason, message represents both of client-side and server-side error. Server-side error difinition depends on underlying server.
+      Error number, reason, message represents both of client-side and server-side error. Server-side error definition depends on underlying server.
       Client-side error definition is implementation dependent and not defined in this document.
       </p>
       <table class="parameters" data-dfn-for="VISError" data-link-for="VISError">

--- a/vehicle_information_api/vehicle_information_api_specification.html
+++ b/vehicle_information_api/vehicle_information_api_specification.html
@@ -145,7 +145,7 @@
       The term 'VIS Server' is used to refer to a server which conforms to the 'VISS' specification.
       </p>
       <p> The term 'VIAS' is used to refer to the 'Vehicle Information API Specification' which is this document.</p>
-      <p> The term 'VSS' is used to refer to the 'Vehicle Signal Specification' (see <a href="https://github.com/GENIVI/vehicle_signal_specification/">here</a>) which is defined in Genivi alliance activity.
+      <p> The term 'VSS' is used to refer to the 'Vehicle Signal Specification' (see <a href="https://github.com/GENIVI/vehicle_signal_specification/">here</a>) which is defined in GENIVI Alliance activity.
       </p>
 
       <p>The term 'WebSocket' when used in this document, is as defined in the W3C WebSocket API (see <a href="https://www.w3.org/TR/2011/WD-websockets-20110929">here</a>) and the WebSocket Protocol (see <a href="https://tools.ietf.org/html/rfc6455">RFC6455</a>).</p>


### PR DESCRIPTION
GENIVI is always spelled with all capital letters
I found some other basic typos also.
