### PR TITLE
Adding error info regarding wrong target of filter  #242

### DIFF
--- a/vehicle_data/vehicle_information_service.html
+++ b/vehicle_data/vehicle_information_service.html
@@ -2447,6 +2447,11 @@ vehicle.close();
 	    <td>The server is unable to fulfil the client request because the request is malformed.</td>
 	  </tr>
 	  <tr>
+	    <td>400 (Bad Request)</td>
+	    <td>bad_filter_request</td>
+	    <td>Filter requested on non-primitive type.</td>
+	  </tr>
+	  <tr>
 	    <td>401 (Unauthorized)</td>
 	    <td>user_token_expired</td>
 	    <td>User token has expired.</td>


### PR DESCRIPTION
Filter cannot be applied to  the branch so it needs to define additional error info for the violated case.
- error code: 400(bad request)
- error reason: bad_filter_requested
- error message: Filter requested on non-primitive type