### PR TITLE
charter-2018:  Remove duplicate VISS description

### DIFF
--- a/charter-2018.html
+++ b/charter-2018.html
@@ -210,10 +210,6 @@
 
               <p class="draft-status"><b>Draft state:</b> Candidate Recommendation@@</p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q2 2018]</i></p>
-              <p>The Vehicle Signal Server Specification defines the semantics of exposing vehicle information through the WebSocket protocol. This specification is dependent upon the Vehicle Signal Specification, as defined by GENIVI.</p>
-
-              <p class="draft-status"><b>Draft state:</b> Candidate Recommendation@@</p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q2 2018]</i></p>
 	    </dd>
 	  </dl>
           <dl>


### PR DESCRIPTION
The exact same text appeared twice in succession.