### PR TITLE
Consolidated the use of American and British English

### DIFF
--- a/vehicle_data/vehicle_information_service.html
+++ b/vehicle_data/vehicle_information_service.html
@@ -1063,8 +1063,8 @@ function subscriptionHandler(msg){
         <p>The Vehicle Signal Server (VSS) specification allows branches to be defined as either public or private. The VIS server will 
 	satisfy a request for metadata in a public branch regardless of the access control permissions associated with the client 
 	making the request. This means that a user could see that a particular signal in a public branch is available but they may not 
-	be currently authorised to Get, Set, or Subscribe to that signal. If a branch is defined to be 'private', only suitably 
-	authorised clients will be able to retrieve metadata for that branch. This is to enable vehicle manufacturers to apply access 
+	be currently authorized to Get, Set, or Subscribe to that signal. If a branch is defined to be 'private', only suitably 
+	authorized clients will be able to retrieve metadata for that branch. This is to enable vehicle manufacturers to apply access 
 	controls to metadata for commercially sensitive signals and data.</p>
 
         <p>      


### PR DESCRIPTION
Changed "authorised" to "authorized" as this spelling was only used in 2 places throughout the document, while the common spelling (including in action names, and tokens) seems to favour (or rather favor) the American English spelling.

Please let me know if:

1. I should continue to consolidate spelling throughout the document on either style
2. I shouldn't bother with trivialities like this
3. I should steer clear of topics like this which are too explosive to reach consensus on