### PR TITLE
Changed timeStamp to timestamp for consistency

### DIFF
--- a/vehicle_information_api/vehicle_information_api_specification.html
+++ b/vehicle_information_api/vehicle_information_api_specification.html
@@ -223,7 +223,7 @@
       dictionary VISValue
       {
         any value;
-        DOMTimeStamp timeStamp;
+        DOMTimeStamp timestamp;
       };
 
       dictionary VISError
@@ -231,7 +231,7 @@
         unsigned short number;
         DOMString? reason;
         DOMString? message;
-        DOMTimeStamp timeStamp;
+        DOMTimeStamp timestamp;
       };
       </pre>
 
@@ -531,7 +531,7 @@
             </td>
           </tr>
           <tr>
-            <td><dfn>timeStamp</dfn></td>
+            <td><dfn>timestamp</dfn></td>
             <td>DOMTimeStamp</td>
             <td>
               The Coordinated Universal Time (UTC) time that the server returned the response (expressed as number of milliseconds.)
@@ -576,7 +576,7 @@
             </td>
           </tr>
           <tr>
-            <td><dfn>timeStamp</dfn></td>
+            <td><dfn>timestamp</dfn></td>
             <td>DOMTimeStamp</td>
             <td>
               The Coordinated Universal Time (UTC) time that the server returned the response (expressed as number of milliseconds.)


### PR DESCRIPTION
For consistency with VISS, change 'timeStamp' to 'timestamp'.