### PR TITLE
Fixed duplicated error

### DIFF
--- a/spec/Gen2_Transport.html
+++ b/spec/Gen2_Transport.html
@@ -156,11 +156,6 @@ extending Gen2 to further transports in the future. The Gen2 supports multiple t
 	  </tr>
 	  <tr>
 	    <td>406 (Not Acceptable)</td>
-	    <td>invalid_token</td>
-	    <td>A new, valid access token must be obtained.</td>
-	  </tr>
-	  <tr>
-	    <td>406 (Not Acceptable)</td>
 	    <td>insufficient_priviledges</td>
 	    <td>The priviledges represented by the access token are not sufficient.</td>
 	  </tr>


### PR DESCRIPTION
- Removed "406 (Not Acceptable) | invalid_token"
- It is duplicated with "401 (Unauthorized) | token_invalid"