### PR TITLE
Fixed duplicated error related to token_missing

### DIFF
--- a/spec/Gen2_Transport.html
+++ b/spec/Gen2_Transport.html
@@ -150,11 +150,6 @@ extending Gen2 to further transports in the future. The Gen2 supports multiple t
 	    <td>The specified subscription was not found.</td>
 	  </tr>
 	  <tr>
-	    <td>404 (Not Found)</td>
-	    <td>missing_token</td>
-	    <td>The addressed node is access controlled, a token must be included in the request.</td>
-	  </tr>
-	  <tr>
 	    <td>406 (Not Acceptable)</td>
 	    <td>invalid_token</td>
 	    <td>A new, valid access token must be obtained.</td>


### PR DESCRIPTION
Removed "404 (Not Found) | missing_token"
It is duplicated with "401 (Unauthorized) | token_missing"