### PR TITLE
Add "filter" attribute to getRequest object on Websocket transport

### DIFF
--- a/spec/VISSv2_Transport.html
+++ b/spec/VISSv2_Transport.html
@@ -585,6 +585,7 @@ extending VISSv2 to further transports in the future. The VISSv2 supports multip
                 <tr><th rowspan="5"><dfn data-dfn-type="dfn" id="dfn-getrequest">getRequest</dfn></th></tr>
                 <tr><td><a href="#dfn-action">action</a></td><td><a href="#action-def">Action</a></td><td>Yes</td></tr>
                 <tr><td><a href="#dfn-path">path</a></td><td>string</td><td>Yes</td></tr>
+	        <tr><td><a href="#dfn-filter">filter</a></td><td>string</td><td>Optional</td></tr>		    
                 <tr><td><a href="#dfn-authorization">authorization</a></td><td>string</td><td>Optional</td></tr>
                 <tr><td><a href="#dfn-requestid">requestId</a></td><td>string</td><td>Yes</td></tr>
             </tbody>


### PR DESCRIPTION
- "filter" attribute is missed in getRequest object on Websocket