### PR TITLE
added error status codes for VISSv2 Transport

### DIFF
--- a/spec/VISSv2_Transport.html
+++ b/spec/VISSv2_Transport.html
@@ -169,6 +169,11 @@ extending VISSv2 to further transports in the future. The VISSv2 supports multip
 	    <td>filter_invalid</td>
 	    <td>Filter requested on non-primitive type.</td>
 	  </tr>
+    <tr>
+	    <td>400 (Bad Request)</td>
+	    <td>invalid_duration</td>
+	    <td>Time duration is invalid.</td>
+	  </tr>
 	  <tr>
 	    <td>401 (Unauthorized)</td>
 	    <td>token_expired</td>
@@ -223,6 +228,11 @@ extending VISSv2 to further transports in the future. The VISSv2 supports multip
 	    <td>404 (Not Found)</td>
 	    <td>private_path</td>
 	    <td>The specified data path is private and the request is not authorized to access signals on this path.</td>
+	  </tr>
+    <tr>
+	    <td>404 (Not Found)</td>
+	    <td>unavailable_data</td>
+	    <td>The requested data was not found.</td>
 	  </tr>
 	  <tr>
 	    <td>404 (Not Found)</td>


### PR DESCRIPTION
- It is to make a sync with 7.2 History Filter Operation section in VISSv2-Core doc
- added two error status codes for history filter operation
- One is to deal with the case of historic data is unavailable
- Another is for invalid time duration value in the request